### PR TITLE
Fix the dependency on PHP_CodeSniffer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
         }
     ],
     "require": {
+        "squizlabs/php_codesniffer": "~1.5",
         "instaclick/symfony2-coding-standard": "dev-remaster",
         "instaclick/object-calisthenics-sniffs": "dev-master"
     },


### PR DESCRIPTION
The CommentParser classes don't exist anymore in 2.0, so this library needs to force using 1.5
